### PR TITLE
Add keyboard shortcuts to resolve #1

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -37,6 +37,21 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
   }
 });
 
+browser.commands.onCommand.addListener(async command => {
+  switch (command) {
+    case 'translate-text':
+      const { id, index } = (await browser.tabs.query({ active: true, currentWindow: true }))[0];
+      const text = (await browser.tabs.executeScript(id, { code: 'getSelection()+""', }))[0];
+      const translateURL = `${deeplURL + defaultLang}/${encodeURIComponent(text)}`;
+      browser.tabs.create({
+        url: translateURL,
+        active: true,
+        index: index + 1,
+        openerTabId: id
+      });
+  }
+});
+
 getDefaultLang();
 
 browser.storage.onChanged.addListener(getDefaultLang);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,5 +15,10 @@
     "browser_style": true,
     "page": "options/options.html",
     "open_in_tab": false
+  },
+  "commands": {
+    "translate-text": {
+      "description": "Send the selected text to DeepL"
+    }
   }
 }


### PR DESCRIPTION
Firefox extensions can have keyboard shortcuts (hotkeys, [commands](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands)). 
While testing in the debugging mode, no additional permissions were needed for hotkeys to work.

This PR adds support for custom hotkeys. User can choose the hotkey in the [Manage Extension Shortcuts](https://support.mozilla.org/en-US/kb/manage-extension-shortcuts-firefox) settings.

The developer of the extension can suggest keyboard shortcuts by adding such a piece of code to the manifest.json:
`"suggested_key": {
      "default": "Alt+Shift+D"
    }`

I haven't suggested any hotkeys in the PR, but you can do so. Fixes #1 