### PR TITLE
Set the source language to a nonsense string to force auto-detection

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,4 @@
-const deeplURL = "https://www.deepl.com/translator#en/"
+const deeplURL = "https://www.deepl.com/translator#null/"
 let defaultLang = "en"
 
 function getDefaultLang() {


### PR DESCRIPTION
Currently, `deeplURL` has a hardcoded source language of `en` which falls apart when using the extension for other source languages. I could not find any definitve documentation on linking to DeepL but I did find that just setting anything that is not a valid language will cause DeepL to autodetect the source language.

This change makes it much more comfortable to use with a wide range of source languages.